### PR TITLE
Fix code scanning alert no. 1: Incomplete URL scheme check

### DIFF
--- a/src/utils/permalinks.ts
+++ b/src/utils/permalinks.ts
@@ -47,7 +47,9 @@ export const getPermalink = (slug = '', type = 'page'): string => {
     slug.startsWith('http://') ||
     slug.startsWith('://') ||
     slug.startsWith('#') ||
-    slug.startsWith('javascript:')
+    slug.trim().toLowerCase().startsWith('javascript:') ||
+    slug.trim().toLowerCase().startsWith('data:') ||
+    slug.trim().toLowerCase().startsWith('vbscript:')
   ) {
     return slug;
   }


### PR DESCRIPTION
Fixes [https://github.com/UnicodeDigital/UnicodeDigital.github.io/security/code-scanning/1](https://github.com/UnicodeDigital/UnicodeDigital.github.io/security/code-scanning/1)

To fix the problem, we need to extend the URL scheme check to include `data:` and `vbscript:` in addition to `javascript:`. This can be done by adding additional conditions to the existing check in the `getPermalink` function.

- Modify the condition on line 50 to include checks for `data:` and `vbscript:`.
- Ensure that the new checks are case-insensitive and handle potential leading whitespace.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
